### PR TITLE
Removed the created_time due to some accounts do not have the created…

### DIFF
--- a/tap_facebook/streams/ad_accounts.py
+++ b/tap_facebook/streams/ad_accounts.py
@@ -124,8 +124,6 @@ class AdAccountsStream(FacebookStream):
     path = f"/adaccounts?fields={columns}"
     tap_stream_id = "adaccounts"
     primary_keys = ["id"]  # noqa: RUF012
-    replication_key = "created_time"
-    replication_method = REPLICATION_INCREMENTAL
 
     schema = PropertiesList(
         Property("account_id", StringType),


### PR DESCRIPTION
## Description
Fixed a key error. Some accounts don't have a created_time which the tap was using as a replication key. This wasn't really a good replication key at any rate.